### PR TITLE
FIX: irnet_ppp.c: TCGETS: Bad address: Add missing negation in ioctl

### DIFF
--- a/src/net/irnet/irnet_ppp.c
+++ b/src/net/irnet/irnet_ppp.c
@@ -766,7 +766,7 @@ dev_irnet_ioctl(
       if(!kernel_termios_to_user_termios((struct termios __user *)argp, &ap->termios))
 	err = 0;
 #else
-      if(kernel_termios_to_user_termios_1((struct termios __user *)argp, &ap->termios))
+      if(!kernel_termios_to_user_termios_1((struct termios __user *)argp, &ap->termios))
 	err = 0;
 #endif
 


### PR DESCRIPTION
IrNet was broken for TCGETS2 due to the missing negation in TCGETS
ioctl. Like the other kernel_termios_* functions (line: 766, 782, 785)
nothing is copied here because ap->termios is NULL.