### PR TITLE
fix #14: when using test_and_set_bit(), target must be volatile unsigned long

### DIFF
--- a/src/include/net/irda/irlan_common.h
+++ b/src/include/net/irda/irlan_common.h
@@ -132,7 +132,7 @@ struct irlan_client_cb {
 	int unicast_open;
 	int broadcast_open;
 
-	int tx_busy;
+	volatile unsigned long tx_busy;
 	struct sk_buff_head txq; /* Transmit control queue */
 
 	struct iriap_cb *iriap;

--- a/src/include/net/irda/irmod.h
+++ b/src/include/net/irda/irmod.h
@@ -94,8 +94,8 @@ void irda_notify_init(notify_t *notify);
 /* Locking wrapper - Note the inverted logic on irda_lock().
  * Those function basically return false if the lock is already in the
  * position you want to set it. - Jean II */
-#define irda_lock(lock)		(! test_and_set_bit(0, (void *) (lock)))
-#define irda_unlock(lock)	(test_and_clear_bit(0, (void *) (lock)))
+#define irda_lock(lock)		(! test_and_set_bit(0, (lock)))
+#define irda_unlock(lock)	(test_and_clear_bit(0, (lock)))
 
 #endif /* IRMOD_H */
 

--- a/src/include/net/irda/irttp.h
+++ b/src/include/net/irda/irttp.h
@@ -120,8 +120,8 @@ struct tsap_cb {
 	struct sk_buff_head tx_queue; /* Frames to be transmitted */
 	struct sk_buff_head rx_queue; /* Received frames */
 	struct sk_buff_head rx_fragments;
-	int tx_queue_lock;
-	int rx_queue_lock;
+	volatile unsigned long tx_queue_lock;
+	volatile unsigned long rx_queue_lock;
 	spinlock_t lock;
 
 	notify_t notify;       /* Callbacks to client layer */


### PR DESCRIPTION
when using (int) instead, this may work on 32-bit platforms, (sizeof int == 4 == sizeof unsigned long), but will
lead to memory corruption on 64-bit platforms (sizeof(int)==4, sizeof(long==8)). luckily the alignment error made this issue visible. it would be better to use appropriate locking types for this, though.

This fixes #14.